### PR TITLE
feat: add typescript/token-tax-calculator example (DeFi tax estimator)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ language, description, and tags to help you find what you need quickly.
 | [typescript/bnbchain-mcp](./typescript/bnbchain-mcp)   | TypeScript | AI-powered blockchain assistant using Claude | AI, BSC, MCP        |
 | [typescript/eliza-chatbot](./typescript/eliza-chatbot) | TypeScript | A chatbot example using Eliza plugin-bnb     | AI, BSC, opBNB      |
 | [typescript/ai-trading-assistant](./typescript/ai-trading-assistant) | Typescript | AI-powered trading assistant for BNB Chain ecosystem with real USDT→BNB swaps via PancakeSwap, technical analysis, and natural language interface | BNBChain, trading, analysis, PancakeSwap, AI, MCP |
+| [typescript/token-tax-calculator](./typescript/token-tax-calculator) | Typescript | Calculates estimated tax implications of token swaps (for education only). | Compliance, DeFi, Accounting |
 More examples are coming soon—stay tuned for updates!
 
 ## How to Add a New Example

--- a/typescript/token-tax-calculator/README.md
+++ b/typescript/token-tax-calculator/README.md
@@ -19,7 +19,7 @@
 
 ## Quick Start (drop-in page)
 
-If you have a Next.js (TypeScript) app, add a page like `/app/tax/page.tsx` and paste:
+If you have a Next.js (TypeScript) app, add a page like `/app/page.tsx` and paste:
 
 ```tsx
 "use client";

--- a/typescript/token-tax-calculator/README.md
+++ b/typescript/token-tax-calculator/README.md
@@ -1,0 +1,214 @@
+# Token Tax Calculator (TypeScript)
+
+**Category:** Compliance / DeFi / Accounting  
+**Summary:** Educational calculator that estimates potential tax on token swaps using simple, configurable rules. **Not legal or tax advice.**
+
+> This example focuses on frontend logic and clear UX—no on-chain calls. It’s meant to show how you can ship a lightweight educational tool in the BNB Chain ecosystem.
+
+---
+
+## Features
+
+- Inputs: buy/sell dates, amounts, cost basis, proceeds, fees
+- Holding period classification (short vs long; thresholds configurable)
+- Simple percentage-based tax estimation
+- Exports a summary breakdown (JSON copy)
+- Zero dependencies beyond a minimal TypeScript/Next.js starter (or you can wire it into any TS app)
+
+---
+
+## Quick Start (drop-in page)
+
+If you have a Next.js (TypeScript) app, add a page like `/app/tax/page.tsx` and paste:
+
+```tsx
+"use client";
+import { useMemo, useState } from "react";
+
+type Inputs = {
+  buyDate: string;
+  sellDate: string;
+  costBasis: number;
+  proceeds: number;
+  fees: number;
+  shortRate: number; // e.g. 22 (%)
+  longRate: number; // e.g. 15 (%)
+  longTermDays: number; // e.g. 365
+};
+
+function daysBetween(a: string, b: string) {
+  const d1 = new Date(a).getTime();
+  const d2 = new Date(b).getTime();
+  if (Number.isNaN(d1) || Number.isNaN(d2)) return 0;
+  return Math.max(0, Math.round((d2 - d1) / (1000 * 60 * 60 * 24)));
+}
+
+export default function TokenTaxCalculator() {
+  const [inp, setInp] = useState<Inputs>({
+    buyDate: "",
+    sellDate: "",
+    costBasis: 0,
+    proceeds: 0,
+    fees: 0,
+    shortRate: 22,
+    longRate: 15,
+    longTermDays: 365,
+  });
+
+  const result = useMemo(() => {
+    const holdingDays = daysBetween(inp.buyDate, inp.sellDate);
+    const longTerm = holdingDays >= inp.longTermDays;
+    const gain = Math.max(0, inp.proceeds - inp.costBasis - inp.fees);
+    const loss = Math.max(0, inp.costBasis + inp.fees - inp.proceeds);
+    const rate = longTerm ? inp.longRate : inp.shortRate;
+    const estTax = (gain * rate) / 100;
+
+    return {
+      holdingDays,
+      longTerm,
+      gain,
+      loss,
+      rate,
+      estTax,
+      netAfterTax: inp.proceeds - inp.fees - estTax,
+    };
+  }, [inp]);
+
+  const onNum = (k: keyof Inputs) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setInp((s) => ({ ...s, [k]: Number(e.target.value) || 0 }));
+
+  const onStr = (k: keyof Inputs) => (e: React.ChangeEvent<HTMLInputElement>) =>
+    setInp((s) => ({ ...s, [k]: e.target.value }));
+
+  return (
+    <div className="p-6 max-w-3xl mx-auto">
+      <h1 className="text-2xl font-semibold mb-4">Token Tax Calculator</h1>
+      <p className="text-sm mb-6">
+        Educational example only. Not legal or tax advice.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Buy Date</span>
+          <input
+            type="date"
+            className="border rounded p-2"
+            value={inp.buyDate}
+            onChange={onStr("buyDate")}
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Sell Date</span>
+          <input
+            type="date"
+            className="border rounded p-2"
+            value={inp.sellDate}
+            onChange={onStr("sellDate")}
+          />
+        </label>
+
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Cost Basis</span>
+          <input
+            type="number"
+            className="border rounded p-2"
+            value={inp.costBasis}
+            onChange={onNum("costBasis")}
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Proceeds</span>
+          <input
+            type="number"
+            className="border rounded p-2"
+            value={inp.proceeds}
+            onChange={onNum("proceeds")}
+          />
+        </label>
+
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Fees</span>
+          <input
+            type="number"
+            className="border rounded p-2"
+            value={inp.fees}
+            onChange={onNum("fees")}
+          />
+        </label>
+
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Long-Term Threshold (days)</span>
+          <input
+            type="number"
+            className="border rounded p-2"
+            value={inp.longTermDays}
+            onChange={onNum("longTermDays")}
+          />
+        </label>
+
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Short-Term Rate (%)</span>
+          <input
+            type="number"
+            className="border rounded p-2"
+            value={inp.shortRate}
+            onChange={onNum("shortRate")}
+          />
+        </label>
+        <label className="flex flex-col">
+          <span className="text-sm mb-1">Long-Term Rate (%)</span>
+          <input
+            type="number"
+            className="border rounded p-2"
+            value={inp.longRate}
+            onChange={onNum("longRate")}
+          />
+        </label>
+      </div>
+
+      <div className="mt-6 border rounded p-4">
+        <h2 className="font-medium mb-2">Result</h2>
+        <ul className="text-sm space-y-1">
+          <li>
+            Holding days: <b>{result.holdingDays}</b> (
+            {result.longTerm ? "Long-term" : "Short-term"})
+          </li>
+          <li>
+            Gain: <b>{result.gain.toFixed(2)}</b> | Loss:{" "}
+            <b>{result.loss.toFixed(2)}</b>
+          </li>
+          <li>
+            Applied rate: <b>{result.rate}%</b>
+          </li>
+          <li>
+            Estimated tax: <b>{result.estTax.toFixed(2)}</b>
+          </li>
+          <li>
+            Net after tax: <b>{result.netAfterTax.toFixed(2)}</b>
+          </li>
+        </ul>
+
+        <button
+          className="mt-3 border rounded px-3 py-2 text-sm"
+          onClick={() => {
+            const payload = {
+              inputs: inp,
+              result,
+              timestamp: new Date().toISOString(),
+            };
+            navigator.clipboard.writeText(JSON.stringify(payload, null, 2));
+            alert("Summary copied to clipboard.");
+          }}
+        >
+          Copy summary JSON
+        </button>
+      </div>
+
+      <p className="text-xs mt-4 opacity-70">
+        Disclaimer: This tool uses simple rules and fixed rates you control
+        above. Tax law varies by jurisdiction.
+      </p>
+    </div>
+  );
+}
+```

--- a/web/list.json
+++ b/web/list.json
@@ -2,11 +2,7 @@
   {
     "caseTitle": "BNB Chain Eliza AgentKit",
     "caseDesc": "Create an AI Agent using the BNB Chain Plugin for Eliza AI",
-    "tags": [
-      "BSC",
-      "opBNB",
-      "AI"
-    ],
+    "tags": ["BSC", "opBNB", "AI"],
     "github": "https://github.com/bnb-chain/example-hub/tree/main/typescript/eliza-chatbot",
     "replit": "https://replit.com/@BNBChainDev/BNBChain-Eliza-AgentKit-TypeScript?embed=true#README.md",
     "video": {},
@@ -17,11 +13,7 @@
   {
     "caseTitle": "BNB Chain LangChain AgentKit",
     "caseDesc": "Create an AI Agent using the BNB Chain Plugin for LangChain AI",
-    "tags": [
-      "BSC",
-      "opBNB",
-      "AI"
-    ],
+    "tags": ["BSC", "opBNB", "AI"],
     "github": "https://github.com/bnb-chain/example-hub/tree/main/python/langchain-chatbot",
     "replit": "https://replit.com/@BNBChainDev/BNBChain-LangChain-AgentKit-Python-Version?embed=true#chatbot.py",
     "video": {},
@@ -32,9 +24,7 @@
   {
     "caseTitle": "EIP 7702 - Demo",
     "caseDesc": "This project demonstrates the implementation of EIP7702 (Account Abstraction via Authorized Operations) on BNB Smart Chain (BSC)",
-    "tags": [
-      "BSC"
-    ],
+    "tags": ["BSC"],
     "github": "https://github.com/bnb-chain/example-hub/tree/main/go/eip7702-demo",
     "replit": "https://replit.com/@BNBChainDev/EIP-7702-Demo?embed=true",
     "video": {},
@@ -83,13 +73,7 @@
   {
     "caseTitle": "BNBChain MCP - AI-Powered Blockchain Assistant",
     "caseDesc": "A ready-to-use template that combines BNB Chain’s MCP with Claude AI, enabling natural language interaction with BNB Smart Chain and Greenfield.",
-    "tags": [
-      "BSC",
-      "Greenfield",
-      "AI",
-      "MCP",
-      "Typescript"
-    ],
+    "tags": ["BSC", "Greenfield", "AI", "MCP", "Typescript"],
     "github": "https://github.com/bnb-chain/example-hub/tree/main/typescript/bnbchain-mcp",
     "replit": "https://replit.com/@BNBChainDev/BNBChain-MCP-With-Anthropic??embed=true",
     "video": {},
@@ -100,12 +84,7 @@
   {
     "caseTitle": "Chainsub – Minimal Smart Contract Event Listener (CLI & Go Package)",
     "caseDesc": "Chainsub is a lightweight and easy-to-use CLI and Go library designed to subscribe and monitor smart contract events on any EVM-compatible blockchain such as BNB Chain, Ethereum, Polygon, Avalanche, and more.",
-    "tags": [
-      "BSC",
-      "Smart Contract Event Listener",
-      "CLI",
-      "GO"
-    ],
+    "tags": ["BSC", "Smart Contract Event Listener", "CLI", "GO"],
     "github": "https://github.com/bnb-chain/example-hub/tree/main/go/event-listener",
     "replit": "",
     "video": {},
@@ -116,13 +95,7 @@
   {
     "caseTitle": "BNB Chain Chatbot with UI (Python)",
     "caseDesc": "This project demonstrates how to create a web interface for the BNB Chain LangChain AgentKit Python chatbot, showcasing how to integrate AI agents into decentralized applications (dApps) through API wrappers.",
-    "tags": [
-      "BSC",
-      "opBNB",
-      "AI",
-      "ChatBot",
-      "Python"
-    ],
+    "tags": ["BSC", "opBNB", "AI", "ChatBot", "Python"],
     "github": "https://github.com/bnb-chain/example-hub/tree/main/python/chatbot-with-ui",
     "replit": "",
     "video": {},
@@ -133,12 +106,7 @@
   {
     "caseTitle": "AI-Powered Reputation NFT Badges on BNB Chain",
     "caseDesc": "Forge unique, soulbound ERC-721 NFT reputation badges on the BNB Chain using data analysis and generative AI. This project analyzes wallet activity, generates insightful explanations via LLMs, and mints NFTs with off-chain metadata stored on IPFS.",
-    "tags": [
-      "BSC",
-      "AI",
-      "NFT",
-      "Python"
-    ],
+    "tags": ["BSC", "AI", "NFT", "Python"],
     "github": "https://github.com/bnb-chain/example-hub/tree/main/python/ai-wallet-reputation-nft",
     "replit": "",
     "video": {},
@@ -149,15 +117,22 @@
   {
     "caseTitle": "4EVERLAND Hosting MCP - AI-Powered Hosting Assistant",
     "caseDesc": "You can deploy your dApp to decentralized networks like Greenfield, IPFS and Arweave with simple AI Chat interface and instantly get an accessible domain.",
-    "tags": [
-      "Greenfield",
-      "AI",
-      "TypeScript"
-    ],
+    "tags": ["Greenfield", "AI", "TypeScript"],
     "github": "https://github.com/bnb-chain/example-hub/tree/main/typescript/4everland-hosting-mcp",
     "replit": "",
     "video": {},
     "guide": "https://github.com/bnb-chain/example-hub/tree/main/typescript/4everland-hosting-mcp",
+    "otherLink": "",
+    "imgUrl": "https://cms-static.bnbchain.org/dcms/static/303d0c6a-af8f-4098-a2d0-a5b96ef964ba.png"
+  },
+  {
+    "caseTitle": "Token Tax Calculator",
+    "caseDesc": "Calculates estimated tax implications of token swaps (for education only).",
+    "tags": ["Compliance", "DeFi", "Accounting"],
+    "github": "https://github.com/flashtxh/example-hub/tree/main/typescript/token-tax-calculator",
+    "replit": "",
+    "video": {},
+    "guide": "https://github.com/flashtxh/example-hub/blob/main/typescript/token-tax-calculator/README.md",
     "otherLink": "",
     "imgUrl": "https://cms-static.bnbchain.org/dcms/static/303d0c6a-af8f-4098-a2d0-a5b96ef964ba.png"
   }


### PR DESCRIPTION
### What’s new
- Adds `typescript/token-tax-calculator` example (educational token swap tax estimator).
- Includes a README with features, quick start code, and disclaimer.
- Updates `web/list.json` with a new catalog entry and guide link.

### Why
- Provides a simple Compliance/Accounting themed demo.
- Low-complexity example showing how to add a frontend-only tool into the hub.

### How to review
1. Open `typescript/token-tax-calculator/README.md` and confirm content.
2. Check `web/list.json` contains the new card with correct title, description, tags, github, and guide.
3. Validate JSON (no trailing commas).

